### PR TITLE
Add pre-order and post-order traversal functions

### DIFF
--- a/bstree.c
+++ b/bstree.c
@@ -200,6 +200,28 @@ int bstree_traverse_inorder(const struct bstree_node *root,
         bstree_traverse_inorder(root->right, it_data, operation));
 }
 
+int bstree_traverse_preorder(const struct bstree_node *root,
+        void *it_data,
+        int (*operation)(void *object, void *it_data))
+{
+    return
+        root &&
+        (operation(root->object, it_data) ||
+        bstree_traverse_preorder(root->left, it_data, operation) ||
+        bstree_traverse_preorder(root->right, it_data, operation));
+}
+
+int bstree_traverse_postorder(const struct bstree_node *root,
+        void *it_data,
+        int (*operation)(void *object, void *it_data))
+{
+    return
+        root &&
+        (bstree_traverse_postorder(root->left, it_data, operation) ||
+        bstree_traverse_postorder(root->right, it_data, operation) ||
+        operation(root->object, it_data));
+}
+
 int bstree_traverse_inorder_cnt(const struct bstree_node *root,
         void *it_data,
         int (*operation)(void *object, void *it_data))
@@ -218,6 +240,50 @@ int bstree_traverse_inorder_cnt(const struct bstree_node *root,
     }
     if (bstree_traverse_inorder_cnt(root->right, it_data, operation)) {
         return 1;
+    }
+    return 0;
+}
+
+int bstree_traverse_preorder_cnt(const struct bstree_node *root,
+        void *it_data,
+        int (*operation)(void *object, void *it_data))
+{
+    int i;
+    if (!root) {
+        return 0;
+    }
+    for (i = 0; i < root->count; i++) {
+        if (operation(root->object, it_data)) {
+            return 1;
+        }
+    }
+    if (bstree_traverse_preorder_cnt(root->left, it_data, operation)) {
+        return 1;
+    }
+    if (bstree_traverse_preorder_cnt(root->right, it_data, operation)) {
+        return 1;
+    }
+    return 0;
+}
+
+int bstree_traverse_postorder_cnt(const struct bstree_node *root,
+        void *it_data,
+        int (*operation)(void *object, void *it_data))
+{
+    int i;
+    if (!root) {
+        return 0;
+    }
+    if (bstree_traverse_postorder_cnt(root->left, it_data, operation)) {
+        return 1;
+    }
+    if (bstree_traverse_postorder_cnt(root->right, it_data, operation)) {
+        return 1;
+    }
+    for (i = 0; i < root->count; i++) {
+        if (operation(root->object, it_data)) {
+            return 1;
+        }
     }
     return 0;
 }

--- a/bstree.h
+++ b/bstree.h
@@ -65,7 +65,7 @@ struct bstree_node *bstree_replace(struct bstree_node *root,
  */
 void bstree_destroy(struct bstree_node *root, const struct bstree_ops *ops);
 
-/* Traverse the tree with a given operation, optionally accumulating
+/* Traverse (in-order) the tree with a given operation, optionally accumulating
  * data in it_data. 'operation' must point to a valid function.
  * Usage of it_data is up to the operation function given by the user.
  * It is not used anywhere by us.
@@ -77,10 +77,48 @@ int bstree_traverse_inorder(const struct bstree_node *root,
         void *it_data,
         int (*operation)(void *object, void *it_data));
 
-/* Traverse the tree in a similar fashion, but apply the operation 'count' times
+/* Traverse (pre-order) the tree with a given operation, optionally accumulating
+ * data in it_data. 'operation' must point to a valid function.
+ * Usage of it_data is up to the operation function given by the user.
+ * It is not used anywhere by us.
+ * Traversal is stopped when the operation returns true.
+ * Returns true if traversal is stopped by the operation function,
+ * else false (traversal is finished by visiting all nodes).
+ */
+int bstree_traverse_preorder(const struct bstree_node *root,
+        void *it_data,
+        int (*operation)(void *object, void *it_data));
+
+/* Traverse (post-order) the tree with a given operation, optionally accumulating
+ * data in it_data. 'operation' must point to a valid function.
+ * Usage of it_data is up to the operation function given by the user.
+ * It is not used anywhere by us.
+ * Traversal is stopped when the operation returns true.
+ * Returns true if traversal is stopped by the operation function,
+ * else false (traversal is finished by visiting all nodes).
+ */
+int bstree_traverse_postorder(const struct bstree_node *root,
+        void *it_data,
+        int (*operation)(void *object, void *it_data));
+
+/* Traverse (in-order) the tree in a similar fashion, but apply the operation 'count' times
  * for each object, 'count' being the count of the object held in the tree.
  */
 int bstree_traverse_inorder_cnt(const struct bstree_node *root,
+        void *it_data,
+        int (*operation)(void *object, void *it_data));
+
+/* Traverse (pre-order) the tree in a similar fashion, but apply the operation 'count' times
+ * for each object, 'count' being the count of the object held in the tree.
+ */
+int bstree_traverse_preorder_cnt(const struct bstree_node *root,
+        void *it_data,
+        int (*operation)(void *object, void *it_data));
+
+/* Traverse (post-order) the tree in a similar fashion, but apply the operation 'count' times
+ * for each object, 'count' being the count of the object held in the tree.
+ */
+int bstree_traverse_postorder_cnt(const struct bstree_node *root,
         void *it_data,
         int (*operation)(void *object, void *it_data));
 

--- a/main.c
+++ b/main.c
@@ -89,7 +89,19 @@ int main(void)
         root = bstree_insert(root, &ops, arr[i]);
         arr[i] = NULL;
     }
+
+    /* inorder print */
     bstree_traverse_inorder(root, NULL, print_int);
+    putchar('\n');
+
+    /* preorder print */
+    bstree_traverse_preorder(root, NULL, print_int);
+    putchar('\n');
+
+    /* postorder print */
+    bstree_traverse_preorder(root, NULL, print_int);
+    putchar('\n');
+
     bstree_traverse_inorder(root, &sum, sum_int);
     printf("\nheight = %d\n", root->height);
     printf("\nsum = %d\n", sum);


### PR DESCRIPTION
Added pre-order and post-order traversal functions and their `cnt` counter-parts. Both functions yield correct results with the `print_int` operation, though I did not test thoroughly with other operations. Please consider merging with master branch.